### PR TITLE
Fix offset() method

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -1079,8 +1079,8 @@ var Sprint;
         if (!el || el.nodeType > 1) return
         var pos = el.getBoundingClientRect()
         return {
-          top: pos.top,
-          left: pos.left
+          top: pos.top + window.pageYOffset,
+          left: pos.left + window.pageXOffset
         }
       }
       if (typeof coordinates == "object") {


### PR DESCRIPTION
The offset method returned a value relative to the viewport.

`pageYOffset` / `pageXOffset` must be added to correct the result and return the offset relative to the whole document, like jQuery does.
