### PR TITLE
Fix height method for document

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -155,10 +155,6 @@ var Sprint;
     })
   }
 
-  var nullNaN = function(val) {
-    return val == val? val : 0
-  }
-
   var getSetDimension = function(obj, prop, value) {
     // get
     if (value == null) {
@@ -169,10 +165,10 @@ var Sprint;
       // dimension of HTML document
       if (el == document) {
         return Math.max(
-          nulNaN(el.body["scroll" + capitalizedProp]),
-          nulNaN(el.body["offset" + capitalizedProp]),
-          nulNaN(root["scroll" + capitalizedProp]),
-          nulNaN(root["offset" + capitalizedProp])
+          el.body["scroll" + capitalizedProp] || 0,
+          el.body["offset" + capitalizedProp] || 0,
+          root["scroll" + capitalizedProp] || 0,
+          root["offset" + capitalizedProp] || 0
         )
       }
       // dimension of viewport

--- a/sprint.js
+++ b/sprint.js
@@ -155,17 +155,28 @@ var Sprint;
     })
   }
 
+  var removeNaN = function(arr) {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] != arr[i]) arr[i] = 0
+    }
+    return arr
+  }
+
   var getSetDimension = function(obj, prop, value) {
     // get
     if (value == null) {
       var el = obj.get(0)
-      if (!el || el.nodeType > 1) return
+      // return if el is neither element nor document node
+      if (!el || (el.nodeType > 1 && el.nodeType != 9)) return
       var capitalizedProp = prop[0].toUpperCase() + prop.substring(1)
       // dimension of HTML document
       if (el == document) {
-        var offset = root["offset" + capitalizedProp]
-        var inner = window["inner" + capitalizedProp]
-        return offset > inner ? offset : inner
+        return Math.max.apply(this, removeNaN([
+          el.body["scroll" + capitalizedProp],
+          el.body["offset" + capitalizedProp],
+          root["scroll" + capitalizedProp],
+          root["offset" + capitalizedProp]
+        ]))
       }
       // dimension of viewport
       if (el == window) {

--- a/sprint.js
+++ b/sprint.js
@@ -155,11 +155,8 @@ var Sprint;
     })
   }
 
-  var removeNaN = function(arr) {
-    for (var i = 0; i < arr.length; i++) {
-      if (arr[i] != arr[i]) arr[i] = 0
-    }
-    return arr
+  var nullNaN = function(val) {
+    return val == val? val : 0
   }
 
   var getSetDimension = function(obj, prop, value) {
@@ -171,12 +168,12 @@ var Sprint;
       var capitalizedProp = prop[0].toUpperCase() + prop.substring(1)
       // dimension of HTML document
       if (el == document) {
-        return Math.max.apply(this, removeNaN([
-          el.body["scroll" + capitalizedProp],
-          el.body["offset" + capitalizedProp],
-          root["scroll" + capitalizedProp],
-          root["offset" + capitalizedProp]
-        ]))
+        return Math.max(
+          nulNaN(el.body["scroll" + capitalizedProp]),
+          nulNaN(el.body["offset" + capitalizedProp]),
+          nulNaN(root["scroll" + capitalizedProp]),
+          nulNaN(root["offset" + capitalizedProp])
+        )
       }
       // dimension of viewport
       if (el == window) {


### PR DESCRIPTION
When the height method was called on the document node (`$(document).height()`), the method just retuned undefined.
This happened because it returned when the `domType > 1`, which is the case for `document`, which has a domType of 9.
- Added an exception for `nodeType == 9` in if clause
- Added compatibility properties for document height / width
- Removed window height as source
